### PR TITLE
Update documentation about using it locally

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,10 +63,12 @@ class youth_allowance_eligible(Variable):
 You can play around with it in a test environment 
 https://courgette-codifier.netlify.app/
 
-### Web Editor
+### Try locally
 
-No installation is required
-Just Download the files and open `index.html` in a browser. 
+No installation is required if you use Firefox. It won't open locally in other browsers due to a security restriction.
+Download the all files and open `index.html` in Firefox.
+
+## Web Editor
 The editor includes:
 - Syntax highlighting and validation
 - Real-time OpenFisca code generation


### PR DESCRIPTION
JavaScript web workers don't work locally except in Firefox.

In Chrome it will display this error in the console and not load:

> Uncaught SecurityError: Failed to construct 'Worker': Script at 'file:///.../CourgetteRules/validator.js' cannot be accessed from origin 'null'.

In Safari it will display a slightly different error in the console:

> [Error] SecurityError: The operation is insecure. Worker (editor.js:5). Global Code (editor.js:5)

Firefox does not have this limitation, so for now I've updated the documentation to be Firefox specific.