### PR TITLE
Fix custom buttons getting squished

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,8 +87,9 @@
       gap: 0.5rem;
     }
     
-    .courgette-buttons button {
+    .ql-toolbar .courgette-buttons button {
       font-size: 0.875rem;
+      width: auto;
     }
     
     /* Status bar */


### PR DESCRIPTION
The 'Add scenario/definition/schedule' buttons were a bit squished. This is a simple CSS fix that unsquishes them.

Before:

<img width="853" height="122" alt="Screenshot 2025-08-11 at 16 26 01" src="https://github.com/user-attachments/assets/ff14f771-ffb0-4e07-8e03-a634d25cc594" />

After:

<img width="851" height="109" alt="Screenshot 2025-08-11 at 16 26 14" src="https://github.com/user-attachments/assets/04e2bea4-3862-44e9-885b-ade00c33d87e" />
